### PR TITLE
Be graceful about unsupported gradient types.

### DIFF
--- a/src/clojure_tensorflow/gradients.clj
+++ b/src/clojure_tensorflow/gradients.clj
@@ -39,8 +39,12 @@
 
 (defn get-registered-gradient
   [node]
-  (let [{output :output which :which} node]
-    (apply (which (get @registered-gradients (.type (.op output)))) (get-inputs output))))
+  (let [{output :output which :which} node
+        grad-type (.type (.op output))
+        grad (get @registered-gradients grad-type)]
+    (when-not grad
+      (throw (ex-info "Gradient not supported yet." {:type grad-type})))
+    (apply (which grad) (get-inputs output))))
 
 (defn collate-paths [from to path-atom path]
   (let [dependents (filter (partial depends-on? to) (get-inputs from))


### PR DESCRIPTION
It is helpful to know when the gradient fails. I really like your work on wrapping tensorflow, cortex is more for users, it does not provide the same auto-differentiation toolbox. I am exploring variational objects like VAEs and my impression from browsing the cortex codebase a bit is that it will be difficult to decompose and compose it for research. It seems like a layer is a central abstraction. Why exactly is the gradient not working automatically for tensorflow on the JVM? 

I am a bit torn as I am more interested in ML for my thesis than in reimplementing an auto-differentiation engine, so I might go back to Python for my master thesis if this does not work out. On the other hand I am exploring composition with Bayesian Program Learning for it and there Anglican is pretty nice. Do you think you can support me to get my VAE stuff going quickly? Do you have a communication channel? I will try to implement the missing gradients then.

In case of a complete graph for auto-differentiation in Clojure I would also like if tensorflow would just be a backend in the long-run, so we could leverage the uncomplicate libs from Dragan Djuric to have a full high-perf compilation pipeline for researchers in Clojure. That is a long-term idea though.