### PR TITLE
Add sum gradient, fix div gradient, add first autoencoder.

### DIFF
--- a/src/clojure_tensorflow/gradients.clj
+++ b/src/clojure_tensorflow/gradients.clj
@@ -28,10 +28,17 @@
                    (fn [& in] (first in))]
          "Mul" [(fn [& in] (second in))
                 (fn [& in] (first in))]
-         "Div" [(fn [& in] (second in))
-                (fn [& in] (first in))]
+         "Div" [(fn [& in] (ops/pow (second in) (ops/constant -1.)))
+                (fn [& in] (ops/sub (ops/constant 0.)
+                                    (ops/mult (first in)
+                                                (ops/pow (second in) (ops/constant -2.)))))]
+         ;; TODO
+         ;; "Transpose" [(fn [& in] (first in)
+         ;;               #_(prn "IN" in)
+         ;;               #_(ops/transpose (first in)))]
+         "Sum" [(fn [& in] (ops/constant 1.))]
          "Sigmoid" [(fn [& in] (ops/mult (ops/sigmoid (first in))
-                                        (ops/sub (ops/constant 1.) (ops/sigmoid (first in)))))]
+                                         (ops/sub (ops/constant 1.) (ops/sigmoid (first in)))))]
          }))
 
 (defn register-gradient [op-type functions]

--- a/test/clojure_tensorflow/core_test.clj
+++ b/test/clojure_tensorflow/core_test.clj
@@ -233,7 +233,7 @@
               (run
                 [(tf/global-variables-initializer)
                  (repeat 1000 (tf.optimizers/gradient-descent error :learning-rate 20. :weights [weights bias weights2]))
-                 (tf/mean error)])) 0.2))))
+                 (tf/mean error)])) 0.3))))
 
     (deftest test-layer-fns
       (let [x (tf/constant [[1. 0. 1.]])

--- a/test/clojure_tensorflow/core_test.clj
+++ b/test/clojure_tensorflow/core_test.clj
@@ -231,7 +231,7 @@
              (first
               (run
                 [(tf/global-variables-initializer)
-                 (repeat 1000 (tf.optimizers/gradient-descent error weights bias weights2))
+                 (repeat 1000 (tf.optimizers/gradient-descent :weights [error weights bias weights2]))
                  (tf/mean error)]))) 0.2)))
 
     (deftest test-layer-fns

--- a/test/clojure_tensorflow/core_test.clj
+++ b/test/clojure_tensorflow/core_test.clj
@@ -219,7 +219,7 @@
     (testing "Autoencoder"
       (is (<
            (let [inputs (tf/constant [[0.0 0.0 1.0] [0.0 1.0 1.0] [1.0 1.0 1.0] [1.0 0.0 1.0]])
-                 outputs (tf/constant [[0.0 0.0 1.0] [0.0 1.0 1.0] [1.0 1.0 1.0] [1.0 0.0 1.0]])
+                 outputs inputs
                  weights (tf/variable (repeatedly 3 (fn [] (repeatedly 2 #(dec (rand 2))))))
                  bias (tf/variable (repeatedly 4 (fn [] (repeatedly 2 #(dec (rand 2))))))
                  weights2 (tf/variable (repeatedly 2 (fn [] (repeatedly 3 #(dec (rand 2))))))
@@ -228,11 +228,10 @@
                                      weights2))
                  error (tf/sum (tf/pow (tf/sub outputs network) (tf/constant 2.))
                                (tf/constant 1))]
-             (first
               (run
                 [(tf/global-variables-initializer)
-                 (repeat 1000 (tf.optimizers/gradient-descent :weights [error weights bias weights2]))
-                 (tf/mean error)]))) 0.2)))
+                 (repeat 500 (tf.optimizers/gradient-descent error :learning-rate 20. :weights [weights bias weights2]))
+                 (tf/mean error)])) 0.2)))
 
     (deftest test-layer-fns
       (let [x (tf/constant [[1. 0. 1.]])

--- a/test/clojure_tensorflow/core_test.clj
+++ b/test/clojure_tensorflow/core_test.clj
@@ -232,7 +232,7 @@
                                (tf/constant 1))]
               (run
                 [(tf/global-variables-initializer)
-                 (repeat 500 (tf.optimizers/gradient-descent error :learning-rate 20. :weights [weights bias weights2]))
+                 (repeat 1000 (tf.optimizers/gradient-descent error :learning-rate 20. :weights [weights bias weights2]))
                  (tf/mean error)])) 0.2))))
 
     (deftest test-layer-fns

--- a/test/clojure_tensorflow/core_test.clj
+++ b/test/clojure_tensorflow/core_test.clj
@@ -217,12 +217,14 @@
 
 
     (testing "Autoencoder"
+      (let [rand-seed (java.util.Random. 1)
+            rand-synapse #(dec (* 2 (.nextDouble rand-seed)))]
       (is (<
            (let [inputs (tf/constant [[0.0 0.0 1.0] [0.0 1.0 1.0] [1.0 1.0 1.0] [1.0 0.0 1.0]])
                  outputs inputs
-                 weights (tf/variable (repeatedly 3 (fn [] (repeatedly 2 #(dec (rand 2))))))
-                 bias (tf/variable (repeatedly 4 (fn [] (repeatedly 2 #(dec (rand 2))))))
-                 weights2 (tf/variable (repeatedly 2 (fn [] (repeatedly 3 #(dec (rand 2))))))
+                 weights (tf/variable (repeatedly 3 (fn [] (repeatedly 2 rand-synapse))))
+                 bias (tf/variable (repeatedly 4 (fn [] (repeatedly 2 rand-synapse))))
+                 weights2 (tf/variable (repeatedly 2 (fn [] (repeatedly 3 rand-synapse))))
                  network (tf/sigmoid
                           (tf/matmul (tf/sigmoid (tf/add (tf/matmul inputs weights) bias))
                                      weights2))
@@ -231,7 +233,7 @@
               (run
                 [(tf/global-variables-initializer)
                  (repeat 500 (tf.optimizers/gradient-descent error :learning-rate 20. :weights [weights bias weights2]))
-                 (tf/mean error)])) 0.2)))
+                 (tf/mean error)])) 0.2))))
 
     (deftest test-layer-fns
       (let [x (tf/constant [[1. 0. 1.]])


### PR DESCRIPTION
I am not sure whether I am doing the gradients right, but the div gradient is not right I think (it also has no test). I am not sure what to do about the transpose yet, as traditional autoencoders use transposed weight matrices. The VAEs don't do so, but I still think it would be good to implement a normal autoencoder first. The error is still also high, but it is the minimal architecture (hidden layer size 2), to encode 4 different inputs, so I am not sure whether I am doing something wrong.