### PR TITLE
Updated to tensorflow 1.15.0.

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,3 @@
+{:deps {org.clojure/clojure {:mvn/version "1.8.0"}
+        org.tensorflow/tensorflow {:mvn/version  "1.15.0"}
+        environ {:mvn/version "1.1.0"}}}

--- a/project.clj
+++ b/project.clj
@@ -5,5 +5,5 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :lein-release {:deploy-via :clojars}
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [org.tensorflow/tensorflow  "1.2.0"]
+                 [org.tensorflow/tensorflow  "1.15.0"]
                  [environ "1.1.0"]])

--- a/src/clojure_tensorflow/utils.clj
+++ b/src/clojure_tensorflow/utils.clj
@@ -43,7 +43,7 @@
   (cond
     (coll? v)
     (if (coll? (first v))
-      (to-array (map tf-vals v))
+      (into-array (map tf-vals v))
       (case (.getName (type (first v)))
         "java.lang.Long" (int-array v)
         "java.lang.Int" (int-array v)


### PR DESCRIPTION
I updated the TensorFlow version from 1.2.0 to 1.15.0. The tests initially failed. I fixed them simply substituting the `to-array` fn for `into-array` fn in the outer array conversion in the `tf-vals` util fn. The problem was `to-array` returns an Object array while `into-array` uses the first value to box the array. 

Now all tests pass and users can use the latest version of Java TensorFlow.